### PR TITLE
Fixed bugs in CPU and GPU versions of the code

### DIFF
--- a/algebra/cuda/sfem_cuda_ShiftedPenalty_impl.cu
+++ b/algebra/cuda/sfem_cuda_ShiftedPenalty_impl.cu
@@ -23,10 +23,8 @@ namespace sfem {
     __device__ T warp_reduce_32(const T in) {
         static_assert(SFEM_WARP_SIZE == 32, "Only implemented for CUDA!");
         T out = in;
-        out += __shfl_xor_sync(
-                SFEM_WARP_FULL_MASK, out, 16, SFEM_WARP_SIZE);  // 0-16, 1-17, ..., 15-31
-        out += __shfl_xor_sync(
-                SFEM_WARP_FULL_MASK, out, 8, SFEM_WARP_SIZE);  // 0-8, ..., 1-7, ..., 23-31
+        out += __shfl_xor_sync(SFEM_WARP_FULL_MASK, out, 16, SFEM_WARP_SIZE);  // 0-16, 1-17, ..., 15-31
+        out += __shfl_xor_sync(SFEM_WARP_FULL_MASK, out, 8, SFEM_WARP_SIZE);   // 0-8, ..., 1-7, ..., 23-31
         out += __shfl_xor_sync(SFEM_WARP_FULL_MASK, out, 4, SFEM_WARP_SIZE);
         out += __shfl_xor_sync(SFEM_WARP_FULL_MASK, out, 2, SFEM_WARP_SIZE);
         out += __shfl_xor_sync(SFEM_WARP_FULL_MASK, out, 1, SFEM_WARP_SIZE);
@@ -47,17 +45,11 @@ namespace sfem {
     __device__ T warp_min_32(const T in) {
         static_assert(SFEM_WARP_SIZE == 32, "Only implemented for CUDA!");
         T out = in;
-        out = tmin(
-                out,
-                __shfl_xor_sync(
-                        SFEM_WARP_FULL_MASK, out, 16, SFEM_WARP_SIZE));  // 0-16, 1-17, ..., 15-31
-        out = tmin(
-                out,
-                __shfl_xor_sync(
-                        SFEM_WARP_FULL_MASK, out, 8, SFEM_WARP_SIZE));  // 0-8, ..., 1-7, ..., 23-31
-        out = tmin(out, __shfl_xor_sync(SFEM_WARP_FULL_MASK, out, 4, SFEM_WARP_SIZE));
-        out = tmin(out, __shfl_xor_sync(SFEM_WARP_FULL_MASK, out, 2, SFEM_WARP_SIZE));
-        out = tmin(out, __shfl_xor_sync(SFEM_WARP_FULL_MASK, out, 1, SFEM_WARP_SIZE));
+        out   = tmin(out, __shfl_xor_sync(SFEM_WARP_FULL_MASK, out, 16, SFEM_WARP_SIZE));  // 0-16, 1-17, ..., 15-31
+        out   = tmin(out, __shfl_xor_sync(SFEM_WARP_FULL_MASK, out, 8, SFEM_WARP_SIZE));   // 0-8, ..., 1-7, ..., 23-31
+        out   = tmin(out, __shfl_xor_sync(SFEM_WARP_FULL_MASK, out, 4, SFEM_WARP_SIZE));
+        out   = tmin(out, __shfl_xor_sync(SFEM_WARP_FULL_MASK, out, 2, SFEM_WARP_SIZE));
+        out   = tmin(out, __shfl_xor_sync(SFEM_WARP_FULL_MASK, out, 1, SFEM_WARP_SIZE));
         return out;
     }
 
@@ -65,17 +57,11 @@ namespace sfem {
     __device__ T warp_max_32(const T in) {
         static_assert(SFEM_WARP_SIZE == 32, "Only implemented for CUDA!");
         T out = in;
-        out = tmax(
-                out,
-                __shfl_xor_sync(
-                        SFEM_WARP_FULL_MASK, out, 16, SFEM_WARP_SIZE));  // 0-16, 1-17, ..., 15-31
-        out = tmax(
-                out,
-                __shfl_xor_sync(
-                        SFEM_WARP_FULL_MASK, out, 8, SFEM_WARP_SIZE));  // 0-8, ..., 1-7, ..., 23-31
-        out = tmax(out, __shfl_xor_sync(SFEM_WARP_FULL_MASK, out, 4, SFEM_WARP_SIZE));
-        out = tmax(out, __shfl_xor_sync(SFEM_WARP_FULL_MASK, out, 2, SFEM_WARP_SIZE));
-        out = tmax(out, __shfl_xor_sync(SFEM_WARP_FULL_MASK, out, 1, SFEM_WARP_SIZE));
+        out   = tmax(out, __shfl_xor_sync(SFEM_WARP_FULL_MASK, out, 16, SFEM_WARP_SIZE));  // 0-16, 1-17, ..., 15-31
+        out   = tmax(out, __shfl_xor_sync(SFEM_WARP_FULL_MASK, out, 8, SFEM_WARP_SIZE));   // 0-8, ..., 1-7, ..., 23-31
+        out   = tmax(out, __shfl_xor_sync(SFEM_WARP_FULL_MASK, out, 4, SFEM_WARP_SIZE));
+        out   = tmax(out, __shfl_xor_sync(SFEM_WARP_FULL_MASK, out, 2, SFEM_WARP_SIZE));
+        out   = tmax(out, __shfl_xor_sync(SFEM_WARP_FULL_MASK, out, 1, SFEM_WARP_SIZE));
         return out;
     }
 
@@ -83,9 +69,9 @@ namespace sfem {
 
     template <typename T>
     __device__ void t_warp_reduce(const T val, T* block_accumulator, T* result) {
-        T acc = warp_reduce_32(val);
+        T                  acc     = warp_reduce_32(val);
         const unsigned int warp_id = threadIdx.x / SFEM_WARP_SIZE;
-        const unsigned int lid = lane_id();
+        const unsigned int lid     = lane_id();
         const unsigned int n_warps = (blockDim.x + SFEM_WARP_SIZE - 1) / SFEM_WARP_SIZE;
 
         if (!lid) {
@@ -107,15 +93,14 @@ namespace sfem {
     }
 
     template <typename T>
-    __global__ void sq_norm_ramp_p_kernel(const ptrdiff_t n, const T* const SFEM_RESTRICT x,
-                                          T* const SFEM_RESTRICT ub,
-                                          T* const SFEM_RESTRICT result) {
-        T ret = 0;
+    __global__ void sq_norm_ramp_p_kernel(const ptrdiff_t              n,
+                                          const T* const SFEM_RESTRICT x,
+                                          const T* const SFEM_RESTRICT ub,
+                                          T* const SFEM_RESTRICT       result) {
         T acc = 0;
-        for (ptrdiff_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n;
-             i += blockDim.x * gridDim.x) {
+        for (ptrdiff_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
             const T diff = tmax(T(0), x[i] - ub[i]);
-            ret += diff * diff;
+            acc += diff * diff;
         }
 
         __shared__ T block_accumulator[SFEM_N_WARPS_PER_BLOCK];
@@ -126,9 +111,8 @@ namespace sfem {
     static T sq_norm_ramp_p_tpl(const ptrdiff_t n, const T* const x, T* const ub) {
         SFEM_DEBUG_SYNCHRONIZE();
 
-        int kernel_block_size = SFEM_WARP_SIZE * SFEM_N_WARPS_PER_BLOCK;
-        ptrdiff_t n_blocks =
-                std::max(ptrdiff_t(1), (n + kernel_block_size - 1) / kernel_block_size);
+        int       kernel_block_size = SFEM_WARP_SIZE * SFEM_N_WARPS_PER_BLOCK;
+        ptrdiff_t n_blocks          = std::max(ptrdiff_t(1), (n + kernel_block_size - 1) / kernel_block_size);
 
         T* device_value = nullptr;
 
@@ -148,15 +132,14 @@ namespace sfem {
     /////
 
     template <typename T>
-    __global__ void sq_norm_ramp_m_kernel(const ptrdiff_t n, const T* const SFEM_RESTRICT x,
-                                          T* const SFEM_RESTRICT lb,
-                                          T* const SFEM_RESTRICT result) {
-        T ret = 0;
+    __global__ void sq_norm_ramp_m_kernel(const ptrdiff_t              n,
+                                          const T* const SFEM_RESTRICT x,
+                                          const T* const SFEM_RESTRICT lb,
+                                          T* const SFEM_RESTRICT       result) {
         T acc = 0;
-        for (ptrdiff_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n;
-             i += blockDim.x * gridDim.x) {
+        for (ptrdiff_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
             const T diff = tmin(T(0), x[i] - lb[i]);
-            ret += diff * diff;
+            acc += diff * diff;
         }
 
         __shared__ T block_accumulator[SFEM_N_WARPS_PER_BLOCK];
@@ -167,9 +150,8 @@ namespace sfem {
     static T sq_norm_ramp_m_tpl(const ptrdiff_t n, const T* const x, T* const lb) {
         SFEM_DEBUG_SYNCHRONIZE();
 
-        int kernel_block_size = SFEM_WARP_SIZE * SFEM_N_WARPS_PER_BLOCK;
-        ptrdiff_t n_blocks =
-                std::max(ptrdiff_t(1), (n + kernel_block_size - 1) / kernel_block_size);
+        int       kernel_block_size = SFEM_WARP_SIZE * SFEM_N_WARPS_PER_BLOCK;
+        ptrdiff_t n_blocks          = std::max(ptrdiff_t(1), (n + kernel_block_size - 1) / kernel_block_size);
 
         T* device_value = nullptr;
 
@@ -189,22 +171,28 @@ namespace sfem {
     /////
 
     template <typename T>
-    __global__ void ramp_p_kernel(const ptrdiff_t n, const T penalty_param, const T* const x,
-                                  const T* const ub, const T* const lagr_ub, T* const out) {
-        for (ptrdiff_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n;
-             i += blockDim.x * gridDim.x) {
+    __global__ void ramp_p_kernel(const ptrdiff_t n,
+                                  const T         penalty_param,
+                                  const T* const  x,
+                                  const T* const  ub,
+                                  const T* const  lagr_ub,
+                                  T* const        out) {
+        for (ptrdiff_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
             out[i] -= penalty_param * tmax(T(0), x[i] - ub[i] + lagr_ub[i] / penalty_param);
         }
     }
 
     template <typename T>
-    static void ramp_p_tpl(const ptrdiff_t n, const T penalty_param, const T* const x,
-                           const T* const ub, const T* const lagr_ub, T* const out) {
+    static void ramp_p_tpl(const ptrdiff_t n,
+                           const T         penalty_param,
+                           const T* const  x,
+                           const T* const  ub,
+                           const T* const  lagr_ub,
+                           T* const        out) {
         SFEM_DEBUG_SYNCHRONIZE();
 
-        int kernel_block_size = SFEM_WARP_SIZE * SFEM_N_WARPS_PER_BLOCK;
-        ptrdiff_t n_blocks =
-                std::max(ptrdiff_t(1), (n + kernel_block_size - 1) / kernel_block_size);
+        int       kernel_block_size = SFEM_WARP_SIZE * SFEM_N_WARPS_PER_BLOCK;
+        ptrdiff_t n_blocks          = std::max(ptrdiff_t(1), (n + kernel_block_size - 1) / kernel_block_size);
 
         ramp_p_kernel<<<n_blocks, kernel_block_size>>>(n, penalty_param, x, ub, lagr_ub, out);
 
@@ -214,22 +202,28 @@ namespace sfem {
     /////
 
     template <typename T>
-    __global__ void ramp_m_kernel(const ptrdiff_t n, const T penalty_param, const T* const x,
-                                  const T* const lb, const T* const lagr_lb, T* const out) {
-        for (ptrdiff_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n;
-             i += blockDim.x * gridDim.x) {
+    __global__ void ramp_m_kernel(const ptrdiff_t n,
+                                  const T         penalty_param,
+                                  const T* const  x,
+                                  const T* const  lb,
+                                  const T* const  lagr_lb,
+                                  T* const        out) {
+        for (ptrdiff_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
             out[i] -= penalty_param * tmin(T(0), x[i] - lb[i] + lagr_lb[i] / penalty_param);
         }
     }
 
     template <typename T>
-    static void ramp_m_tpl(const ptrdiff_t n, const T penalty_param, const T* const x,
-                           const T* const lb, const T* const lagr_lb, T* const out) {
+    static void ramp_m_tpl(const ptrdiff_t n,
+                           const T         penalty_param,
+                           const T* const  x,
+                           const T* const  lb,
+                           const T* const  lagr_lb,
+                           T* const        out) {
         SFEM_DEBUG_SYNCHRONIZE();
 
-        int kernel_block_size = SFEM_WARP_SIZE * SFEM_N_WARPS_PER_BLOCK;
-        ptrdiff_t n_blocks =
-                std::max(ptrdiff_t(1), (n + kernel_block_size - 1) / kernel_block_size);
+        int       kernel_block_size = SFEM_WARP_SIZE * SFEM_N_WARPS_PER_BLOCK;
+        ptrdiff_t n_blocks          = std::max(ptrdiff_t(1), (n + kernel_block_size - 1) / kernel_block_size);
 
         ramp_m_kernel<<<n_blocks, kernel_block_size>>>(n, penalty_param, x, lb, lagr_lb, out);
 
@@ -239,22 +233,26 @@ namespace sfem {
     /////
 
     template <typename T>
-    __global__ void update_lagr_p_kernel(const ptrdiff_t n, const T penalty_param, const T* const x,
-                                         const T* const ub, T* const lagr_ub) {
-        for (ptrdiff_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n;
-             i += blockDim.x * gridDim.x) {
+    __global__ void update_lagr_p_kernel(const ptrdiff_t n,
+                                         const T         penalty_param,
+                                         const T* const  x,
+                                         const T* const  ub,
+                                         T* const        lagr_ub) {
+        for (ptrdiff_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
             lagr_ub[i] = tmax(T(0), lagr_ub[i] + penalty_param * (x[i] - ub[i]));
         }
     }
 
     template <typename T>
-    static void update_lagr_p_tpl(const ptrdiff_t n, const T penalty_param, const T* const x,
-                                  const T* const ub, T* const lagr_ub) {
+    static void update_lagr_p_tpl(const ptrdiff_t n,
+                                  const T         penalty_param,
+                                  const T* const  x,
+                                  const T* const  ub,
+                                  T* const        lagr_ub) {
         SFEM_DEBUG_SYNCHRONIZE();
 
-        int kernel_block_size = SFEM_WARP_SIZE * SFEM_N_WARPS_PER_BLOCK;
-        ptrdiff_t n_blocks =
-                std::max(ptrdiff_t(1), (n + kernel_block_size - 1) / kernel_block_size);
+        int       kernel_block_size = SFEM_WARP_SIZE * SFEM_N_WARPS_PER_BLOCK;
+        ptrdiff_t n_blocks          = std::max(ptrdiff_t(1), (n + kernel_block_size - 1) / kernel_block_size);
 
         update_lagr_p_kernel<<<n_blocks, kernel_block_size>>>(n, penalty_param, x, ub, lagr_ub);
 
@@ -264,22 +262,26 @@ namespace sfem {
     /////
 
     template <typename T>
-    __global__ void update_lagr_m_kernel(const ptrdiff_t n, const T penalty_param, const T* const x,
-                                         const T* const lb, T* const lagr_lb) {
-        for (ptrdiff_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n;
-             i += blockDim.x * gridDim.x) {
+    __global__ void update_lagr_m_kernel(const ptrdiff_t n,
+                                         const T         penalty_param,
+                                         const T* const  x,
+                                         const T* const  lb,
+                                         T* const        lagr_lb) {
+        for (ptrdiff_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
             lagr_lb[i] = tmin(T(0), lagr_lb[i] + penalty_param * (x[i] - lb[i]));
         }
     }
 
     template <typename T>
-    static void update_lagr_m_tpl(const ptrdiff_t n, const T penalty_param, const T* const x,
-                                  const T* const lb, T* const lagr_lb) {
+    static void update_lagr_m_tpl(const ptrdiff_t n,
+                                  const T         penalty_param,
+                                  const T* const  x,
+                                  const T* const  lb,
+                                  T* const        lagr_lb) {
         SFEM_DEBUG_SYNCHRONIZE();
 
-        int kernel_block_size = SFEM_WARP_SIZE * SFEM_N_WARPS_PER_BLOCK;
-        ptrdiff_t n_blocks =
-                std::max(ptrdiff_t(1), (n + kernel_block_size - 1) / kernel_block_size);
+        int       kernel_block_size = SFEM_WARP_SIZE * SFEM_N_WARPS_PER_BLOCK;
+        ptrdiff_t n_blocks          = std::max(ptrdiff_t(1), (n + kernel_block_size - 1) / kernel_block_size);
 
         update_lagr_m_kernel<<<n_blocks, kernel_block_size>>>(n, penalty_param, x, lb, lagr_lb);
 
@@ -287,44 +289,50 @@ namespace sfem {
     }
 
     template <typename T>
-    __global__ void calc_J_pen_p_kernel(const ptrdiff_t n, const T* const x, const T penalty_param,
-                                        const T* const ub, const T* const lagr_ub,
-                                        T* const result) {
-        for (ptrdiff_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n;
-             i += blockDim.x * gridDim.x) {
+    __global__ void calc_J_pen_p_kernel(const ptrdiff_t n,
+                                        const T* const  x,
+                                        const T         penalty_param,
+                                        const T* const  ub,
+                                        const T* const  lagr_ub,
+                                        T* const        result) {
+        for (ptrdiff_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
             result[i] += ((x[i] - ub[i] + lagr_ub[i] / penalty_param) >= 0) * penalty_param;
         }
     }
 
     template <typename T>
-    __global__ void calc_J_pen_m_kernel(const ptrdiff_t n, const T* const x, const T penalty_param,
-                                        const T* const lb, const T* const lagr_lb,
-                                        T* const result) {
-        for (ptrdiff_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n;
-             i += blockDim.x * gridDim.x) {
+    __global__ void calc_J_pen_m_kernel(const ptrdiff_t n,
+                                        const T* const  x,
+                                        const T         penalty_param,
+                                        const T* const  lb,
+                                        const T* const  lagr_lb,
+                                        T* const        result) {
+        for (ptrdiff_t i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += blockDim.x * gridDim.x) {
             result[i] += ((x[i] - lb[i] + lagr_lb[i] / penalty_param) <= 0) * penalty_param;
         }
     }
 
     ///
     template <typename T>
-    static void calc_J_pen_tpl(const ptrdiff_t n, const T* const x, const T penalty_param,
-                               const T* const lb, const T* const ub, const T* const lagr_lb,
-                               const T* const lagr_ub, T* const result) {
+    static void calc_J_pen_tpl(const ptrdiff_t n,
+                               const T* const  x,
+                               const T         penalty_param,
+                               const T* const  lb,
+                               const T* const  ub,
+                               const T* const  lagr_lb,
+                               const T* const  lagr_ub,
+                               T* const        result) {
         SFEM_DEBUG_SYNCHRONIZE();
 
-        int kernel_block_size = SFEM_WARP_SIZE * SFEM_N_WARPS_PER_BLOCK;
-        ptrdiff_t n_blocks =
-                std::max(ptrdiff_t(1), (n + kernel_block_size - 1) / kernel_block_size);
+        int       kernel_block_size = SFEM_WARP_SIZE * SFEM_N_WARPS_PER_BLOCK;
+        ptrdiff_t n_blocks          = std::max(ptrdiff_t(1), (n + kernel_block_size - 1) / kernel_block_size);
 
         if (lb) {
-            calc_J_pen_m_kernel<<<n_blocks, kernel_block_size>>>(
-                    n, x, penalty_param, lb, lagr_lb, result);
+            calc_J_pen_m_kernel<<<n_blocks, kernel_block_size>>>(n, x, penalty_param, lb, lagr_lb, result);
         }
 
         if (ub) {
-            calc_J_pen_p_kernel<<<n_blocks, kernel_block_size>>>(
-                    n, x, penalty_param, ub, lagr_ub, result);
+            calc_J_pen_p_kernel<<<n_blocks, kernel_block_size>>>(n, x, penalty_param, ub, lagr_ub, result);
         }
 
         SFEM_DEBUG_SYNCHRONIZE();
@@ -334,21 +342,21 @@ namespace sfem {
     void CUDA_ShiftedPenalty<T>::build(struct ShiftedPenalty_Tpl<T>& tpl) {
         tpl.sq_norm_ramp_p = &sq_norm_ramp_p_tpl<T>;
         tpl.sq_norm_ramp_m = &sq_norm_ramp_m_tpl<T>;
-        tpl.ramp_p = &ramp_p_tpl<T>;
-        tpl.ramp_m = &ramp_m_tpl<T>;
-        tpl.update_lagr_p = &update_lagr_p_tpl<T>;
-        tpl.update_lagr_m = &update_lagr_m_tpl<T>;
+        tpl.ramp_p         = &ramp_p_tpl<T>;
+        tpl.ramp_m         = &ramp_m_tpl<T>;
+        tpl.update_lagr_p  = &update_lagr_p_tpl<T>;
+        tpl.update_lagr_m  = &update_lagr_m_tpl<T>;
 
-        auto ramp_m = tpl.ramp_m;
-        auto ramp_p = tpl.ramp_p;
+        auto ramp_m    = tpl.ramp_m;
+        auto ramp_p    = tpl.ramp_p;
         tpl.calc_r_pen = [ramp_m, ramp_p](const ptrdiff_t n,
-                                          T* const x,
-                                          const T penalty_param,
-                                          const T* const lb,
-                                          const T* const ub,
-                                          const T* const lagr_lb,
-                                          const T* const lagr_ub,
-                                          T* result) {
+                                          T* const        x,
+                                          const T         penalty_param,
+                                          const T* const  lb,
+                                          const T* const  ub,
+                                          const T* const  lagr_lb,
+                                          const T* const  lagr_ub,
+                                          T*              result) {
             // Ramp negative and positive parts
             if (lb) ramp_m(n, penalty_param, x, lb, lagr_lb, result);
             if (ub) ramp_p(n, penalty_param, x, ub, lagr_ub, result);

--- a/algebra/openmp/sfem_ShiftedPenalty_impl.hpp
+++ b/algebra/openmp/sfem_ShiftedPenalty_impl.hpp
@@ -47,7 +47,7 @@ namespace sfem {
         static void build(struct ShiftedPenalty_Tpl<T>& tpl) {
             tpl.sq_norm_ramp_p = [](const ptrdiff_t n, const T* const x, T* const ub) -> T {
                 T ret = 0;
-#pragma omp parallel for reduction(+ : ret)
+#pragma omp parallel for reduction(+: ret)
                 for (ptrdiff_t i = 0; i < n; i++) {
                     const T diff = std::max(T(0), x[i] - ub[i]);
                     ret += diff * diff;
@@ -57,7 +57,7 @@ namespace sfem {
 
             tpl.sq_norm_ramp_m = [](const ptrdiff_t n, const T* const x, T* const lb) -> T {
                 T ret = 0;
-#pragma omp parallel for reduction(+ : ret)
+#pragma omp parallel for reduction(+: ret)
                 for (ptrdiff_t i = 0; i < n; i++) {
                     const T diff = std::min(T(0), x[i] - lb[i]);
                     ret += diff * diff;

--- a/base/sfem_test.h
+++ b/base/sfem_test.h
@@ -96,6 +96,29 @@ static inline int sfem_test_assert_approxeq(double a, double b, double tol, cons
     return 0;
 }
 
+static inline int sfem_assert_array_approx_eq(const ptrdiff_t i,
+                                              double          a,
+                                              double          b,
+                                              double          tol,
+                                              const char     *file,
+                                              const int       line) {
+    if (fabs(a - b) > tol) {
+        fprintf(stderr,
+                "\nAssertion failure at entry %ld: %g != %g (diff %g > %g) \nAt %s:%d\n\n",
+                i,
+                a,
+                b,
+                fabs(a - b),
+                tol,
+                file,
+                line);
+        assert(0);
+        return SFEM_TEST_FAILURE;
+    }
+
+    return 0;
+}
+
 #define SFEM_TEST_ASSERT(expr)                                                    \
     if (sfem_test_assert(expr, #expr, __FILE__, __LINE__) == SFEM_TEST_FAILURE) { \
         return SFEM_TEST_FAILURE;                                                 \
@@ -106,10 +129,16 @@ static inline int sfem_test_assert_approxeq(double a, double b, double tol, cons
         return SFEM_TEST_FAILURE;                                                        \
     }
 
-#define SFEM_ASSERT_ARRAY_APPROX_EQ(n__, a__, b__, tol__) \
-    for (ptrdiff_t i__ = 0; i__ < n__; i__++) {           \
-        SFEM_TEST_APPROXEQ(a__[i__], b__[i__], tol__);    \
-    }
+#define SFEM_ASSERT_ARRAY_APPROX_EQ(n__, a__, b__, tol__)                                                               \
+    do {                                                                                                                \
+        ptrdiff_t nfails = 0;                                                                                           \
+        for (ptrdiff_t i__ = 0; i__ < (n__); i__++) {                                                                     \
+            if (sfem_assert_array_approx_eq(i__, (a__)[i__], (b__)[i__], tol__, __FILE__, __LINE__) == SFEM_TEST_FAILURE) { \
+                nfails++;                                                                                                \
+            }                                                                                                           \
+        }                                                                                                               \
+        if (nfails) return SFEM_TEST_FAILURE;                                                                           \
+    } while (0)
 
 #ifdef __cplusplus
 }

--- a/frontend/tests/sfem_NewmarkTest.cpp
+++ b/frontend/tests/sfem_NewmarkTest.cpp
@@ -198,7 +198,7 @@ int test_newmark() {
     auto g         = sfem::create_buffer<real_t>(ndofs, es);
 
     real_t dt          = 0.2;
-    real_t T           = 2;
+    real_t T           = 4;
     size_t export_freq = 1;
     size_t steps       = 0;
     real_t t           = 0;

--- a/operators/sshex8/sshex8_linear_elasticity.c
+++ b/operators/sshex8/sshex8_linear_elasticity.c
@@ -389,9 +389,9 @@ int affine_sshex8_linear_elasticity_apply(const int                    level,
 
                         for (int d = 0; d < 8; d++) {
                             const int lidx = lev[d];
-                            element_ux[d] = eu[0][lidx];
-                            element_uy[d] = eu[1][lidx];
-                            element_uz[d] = eu[2][lidx];
+                            element_ux[d]  = eu[0][lidx];
+                            element_uy[d]  = eu[1][lidx];
+                            element_uz[d]  = eu[2][lidx];
                         }
 
                         for (int d = 0; d < 3 * 8; d++) {
@@ -820,11 +820,17 @@ int affine_sshex8_linear_elasticity_block_diag_sym(const int                    
                         for (int edof_i = 0; edof_i < 8; edof_i++) {
                             const ptrdiff_t v = ev[lev[edof_i]];
                             // local to global
+#pragma omp atomic update
                             out0[v * out_stride] += blocks[edof_i][0];
+#pragma omp atomic update
                             out1[v * out_stride] += blocks[edof_i][1];
+#pragma omp atomic update
                             out2[v * out_stride] += blocks[edof_i][2];
+#pragma omp atomic update
                             out3[v * out_stride] += blocks[edof_i][3];
+#pragma omp atomic update
                             out4[v * out_stride] += blocks[edof_i][4];
+#pragma omp atomic update
                             out5[v * out_stride] += blocks[edof_i][5];
                         }
                     }

--- a/python/codegen/gpu_linear_elasticity_op.py
+++ b/python/codegen/gpu_linear_elasticity_op.py
@@ -267,7 +267,7 @@ class GPULinearElasticityOp:
         dims = fe.manifold_dim()
         q = fe.quadrature_point()
         shape_grad = fe.physical_tgrad(q)
-        eval_strain = sp.zeros(3, 3)
+        eval_strain = sp.zeros(dims, dims)
 
         for i in range(0, dims * fe.n_nodes()):
             eval_strain += disp[i] * (shape_grad[i] + shape_grad[i].T) / 2


### PR DESCRIPTION
This pull request focuses on improving code readability, consistency, and correctness in CUDA-based implementations and test utilities. The changes include formatting adjustments, variable renaming for clarity, and enhancements to assertion macros for better debugging.

### CUDA Kernel Improvements and Formatting Adjustments:
* Improved formatting in `warp_reduce_32`, `warp_min_32`, and `warp_max_32` functions by aligning parameters for better readability in `sfem_cuda_ShiftedPenalty_impl.cu`. [[1]](diffhunk://#diff-127789efe4dfdcd68ee542ddd45fb6c5404cc232a41e454cd1c88527696a6874L26-R27) [[2]](diffhunk://#diff-127789efe4dfdcd68ee542ddd45fb6c5404cc232a41e454cd1c88527696a6874L50-R49) [[3]](diffhunk://#diff-127789efe4dfdcd68ee542ddd45fb6c5404cc232a41e454cd1c88527696a6874L68-R61)
* Replaced redundant variable `ret` with `acc` in kernel functions like `sq_norm_ramp_p_kernel` and `sq_norm_ramp_m_kernel` to simplify and unify accumulation logic. [[1]](diffhunk://#diff-127789efe4dfdcd68ee542ddd45fb6c5404cc232a41e454cd1c88527696a6874L110-R103) [[2]](diffhunk://#diff-127789efe4dfdcd68ee542ddd45fb6c5404cc232a41e454cd1c88527696a6874L151-R142)
* Standardized block size calculation and kernel launch patterns across multiple functions to ensure consistency. [[1]](diffhunk://#diff-127789efe4dfdcd68ee542ddd45fb6c5404cc232a41e454cd1c88527696a6874L130-R115) [[2]](diffhunk://#diff-127789efe4dfdcd68ee542ddd45fb6c5404cc232a41e454cd1c88527696a6874L171-R154) [[3]](diffhunk://#diff-127789efe4dfdcd68ee542ddd45fb6c5404cc232a41e454cd1c88527696a6874L192-R195) [[4]](diffhunk://#diff-127789efe4dfdcd68ee542ddd45fb6c5404cc232a41e454cd1c88527696a6874L217-R226) [[5]](diffhunk://#diff-127789efe4dfdcd68ee542ddd45fb6c5404cc232a41e454cd1c88527696a6874L242-R255) [[6]](diffhunk://#diff-127789efe4dfdcd68ee542ddd45fb6c5404cc232a41e454cd1c88527696a6874L267-R335)

### Test Utility Enhancements:
* Added a new function `sfem_assert_array_approx_eq` to provide detailed failure information for array comparisons, improving test debugging capabilities in `sfem_test.h`.
* Updated `SFEM_ASSERT_ARRAY_APPROX_EQ` macro to count failures and return a failure code when any assertion fails, ensuring more robust test handling.

### Frontend Code Refinements:
* Removed redundant `element_type` member in `SemiStructuredGPULinearElasticity` and replaced it with a method call to `derefined_space->element_type()` for better encapsulation in `sfem_Function_incore_cuda.cpp`. [[1]](diffhunk://#diff-a91d043aa56e1ce3629f0f73ec60fb08ddb77da84f009f204cddde3f019e6647L665) [[2]](diffhunk://#diff-a91d043aa56e1ce3629f0f73ec60fb08ddb77da84f009f204cddde3f019e6647L685-L692)
* Updated initialization of material properties (`SFEM_SHEAR_MODULUS` and `SFEM_FIRST_LAME_PARAMETER`) to use class members `mu` and `lambda`, allowing for dynamic configuration.